### PR TITLE
Fix autoprefixer

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,7 +54,10 @@ gulp.task("sass", function() {
 	.pipe(sassLint.format())
 	.pipe(sassLint.failOnError())
 	.pipe(sass().on("error", sass.logError))
-	.pipe(autoprefixer())
+	.pipe(autoprefixer({
+		browsers: ['last 2 versions'],
+		cascade: false
+	}))
 	.pipe(sourcemaps.write('./'))
 	.pipe(gulp.dest(paths.destination.css))
 	.pipe(notify({


### PR DESCRIPTION
Currently the autoprefixer doesn't work at all. It needs arguments to specify targeted compatibility.